### PR TITLE
Add DrawSelectedAsync() and clear draw queues at the end of each frame

### DIFF
--- a/Scripts/GizmosPlusAsync.cs
+++ b/Scripts/GizmosPlusAsync.cs
@@ -1,4 +1,3 @@
-
 using System;
 using UnityEngine;
 
@@ -8,6 +7,16 @@ namespace Zchfvy.Plus {
     /// </summary>
     public static class GizmosPlusAsync {
         private static GizmosPlusAsyncDrawer drawer;
+
+        private static GizmosPlusAsyncDrawer GetOrCreateDrawer() {
+            if (drawer == null) {
+                var go = new GameObject("_GizmosPlusAsyncDrawer");
+                drawer = go.AddComponent<GizmosPlusAsyncDrawer>();
+            }
+
+            return drawer;
+        }
+
         /// <summary>
         /// Allows drawing of Gizmos outside of OnDrawGizmos flow
         /// </summary>
@@ -24,11 +33,15 @@ namespace Zchfvy.Plus {
         /// </code>
         /// </example>
         public static void DrawAsync(Action drawFunc) {
-            if (drawer == null) {
-                var go = new GameObject("_GizmosPlusAsyncDrawer");
-                drawer = go.AddComponent<GizmosPlusAsyncDrawer>();
-            }
-            drawer.Enqueue(drawFunc);
+            GetOrCreateDrawer().Enqueue(drawFunc);
+        }
+
+        public static void DrawSelectedAsync(this GameObject gameObject, Action drawFunc) {
+            GetOrCreateDrawer().EnqueueSelected(gameObject, drawFunc);
+        }
+
+        public static void DrawSelectedAsync<T>(this T component, Action drawFunc) where T : Component {
+            DrawSelectedAsync(component.gameObject, drawFunc);
         }
     }
 }

--- a/Scripts/GizmosPlusAsync.cs
+++ b/Scripts/GizmosPlusAsync.cs
@@ -36,10 +36,52 @@ namespace Zchfvy.Plus {
             GetOrCreateDrawer().Enqueue(drawFunc);
         }
 
+        /// <summary>
+        /// Performs the provided draw logic when the specified game object is selected in the
+        /// scene view.
+        /// </summary>
+        ///
+        /// <param name="gameObject">
+        /// The object that must be selected in order for the gizmos to be drawn.
+        /// </param>
+        /// <param name="drawFunc">
+        /// A lambda expression that performs the gizmo drawing logic.
+        /// </param>
+        ///
+        /// <example>
+        /// In some main thread function other than <c>OnDrawGizmosSelected()</c>:
+        /// <code>
+        /// GizmosPlusAsync.DrawSelectedAsync(targetObject, () => {
+        ///     Gizmos.DrawLine(...);
+        ///     GizmosPlus.DrawCross(...);
+        /// });
+        /// </code>
+        /// </example>
         public static void DrawSelectedAsync(this GameObject gameObject, Action drawFunc) {
             GetOrCreateDrawer().EnqueueSelected(gameObject, drawFunc);
         }
 
+        /// <summary>
+        /// Performs the provided draw logic when the specified component is selected in the
+        /// scene view.
+        /// </summary>
+        ///
+        /// <param name="component">
+        /// A component on the object that must be selected in order for the gizmos to be drawn.
+        /// </param>
+        /// <param name="drawFunc">
+        /// A lambda expression that performs the gizmo drawing logic.
+        /// </param>
+        ///
+        /// <example>
+        /// In some main thread function other than <c>OnDrawGizmosSelected()</c>:
+        /// <code>
+        /// GizmosPlusAsync.DrawSelectedAsync(this, () => {
+        ///     Gizmos.DrawLine(...);
+        ///     GizmosPlus.DrawCross(...);
+        /// });
+        /// </code>
+        /// </example>
         public static void DrawSelectedAsync<T>(this T component, Action drawFunc) where T : Component {
             DrawSelectedAsync(component.gameObject, drawFunc);
         }

--- a/Scripts/GizmosPlusAsyncDrawer.cs
+++ b/Scripts/GizmosPlusAsyncDrawer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -19,6 +20,10 @@ namespace Zchfvy.Plus {
             drawSelectedQueue.Enqueue((gameObject, newItem));
         }
 
+        private void Awake() {
+            StartCoroutine(ClearDrawQueues());
+        }
+
         void OnDrawGizmos() {
             while (drawQueue.Count > 0) {
                 var act = drawQueue.Dequeue();
@@ -33,6 +38,28 @@ namespace Zchfvy.Plus {
                     act();
                 }
 #endif
+            }
+        }
+
+        /// <summary>
+        /// Clears the draw queues at the end of each frame.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// In the editor the draw queues are emptied automatically in <see cref="OnDrawGizmos"/>.
+        /// However, if there is no scene view window in the editor then <see cref="OnDrawGizmos"/>
+        /// is never called. This is also the case for the built player. To avoid accumulating
+        /// draw calls forever in these cases (which would eventually lead to out of memory
+        /// errors), we clear the draw queues at the end of every frame. This is specifically
+        /// setup as a coroutine because <see cref="WaitForEndOfFrame"/> is the latest script
+        /// lifecycle event that happens in the update loop, meaning that we can reliably clear
+        /// the draw queues at that point without "losing" any drawn gizmos.
+        /// </remarks>
+        private IEnumerator ClearDrawQueues() {
+            while (true) {
+                yield return new WaitForEndOfFrame();
+                drawQueue.Clear();
+                drawSelectedQueue.Clear();
             }
         }
     }

--- a/Scripts/GizmosPlusAsyncDrawer.cs
+++ b/Scripts/GizmosPlusAsyncDrawer.cs
@@ -9,15 +9,30 @@ namespace Zchfvy.Plus {
     /// </summary>
     public class GizmosPlusAsyncDrawer : MonoBehaviour {
         private Queue<Action> drawQueue = new Queue<Action>();
+        private Queue<(GameObject, Action)> drawSelectedQueue = new Queue<(GameObject, Action)>();
 
         public void Enqueue(Action newItem) {
             drawQueue.Enqueue(newItem);
+        }
+
+        public void EnqueueSelected(GameObject gameObject, Action newItem) {
+            drawSelectedQueue.Enqueue((gameObject, newItem));
         }
 
         void OnDrawGizmos() {
             while (drawQueue.Count > 0) {
                 var act = drawQueue.Dequeue();
                 act();
+            }
+
+            while (drawSelectedQueue.Count > 0) {
+                var (gameObject, act) = drawSelectedQueue.Dequeue();
+
+#if UNITY_EDITOR
+                if (UnityEditor.Selection.Contains(gameObject.GetInstanceID())) {
+                    act();
+                }
+#endif
             }
         }
     }


### PR DESCRIPTION
This PR adds `GizmosPlusAsync.DrawSelectedAsync()` as an equivalent for the built-in `OnDrawGizmosSelected()` for `GizmosPlusAsync`. This allows users to perform async gizmo drawing that will only execute when the specified object is selected in the scene view, which helps to cut down on the number of gizmos drawn if there are many objects in the scene that potentially want to be drawing gizmos. In doing so, I also factored out the logic for lazily creating the drawer object into a `GetOrCreateDrawer()` helper method, since it is now used from multiple places.

While working on this, I noticed that `drawQueue` (and now also `drawQueueSelected`) would not get cleared if `OnDrawGizmos()` isn't called. This will always be the case in a built player, but in the editor this can also happen if there is no active scene view. In order to prevent the draw queues from growing infinitely in these cases I've added a helper coroutine `ClearDrawQueues()` that runs in the background and clears the draw queues at the end of each frame.

Please let me know if you have any questions/feedback about the proposed feature, I'm happy to make changes based on any requests or suggestions!